### PR TITLE
Restoration of CSGO vdf file

### DIFF
--- a/dist/csgo/addons/metamod.vdf
+++ b/dist/csgo/addons/metamod.vdf
@@ -1,0 +1,4 @@
+"Plugin"
+{
+	"file"	"../csgo/addons/metamod/bin/server"
+}


### PR DESCRIPTION
Restoration of CSGO vdf file. Without this file sourcemod/metamod would not run